### PR TITLE
[#14] [Integrate] As a user, I can see the iOS 11 UIKit Screen with Dynamic Custom Font

### DIFF
--- a/CustomDynamicFont.xcodeproj/project.pbxproj
+++ b/CustomDynamicFont.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		096C3132273E18B6009497A5 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C3131273E18B6009497A5 /* R.generated.swift */; };
 		09B254B6274281E800D3E7F8 /* SelectOSViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */; };
 		096C3134273E293F009497A5 /* UIStackView+Subviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C3133273E293F009497A5 /* UIStackView+Subviews.swift */; };
+		096C31612742296E009497A5 /* UIKitViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C31602742296E009497A5 /* UIKitViewModel.swift */; };
+		096C316327422B88009497A5 /* Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C316227422B88009497A5 /* Lifecycle.swift */; };
+		096C316527422BBD009497A5 /* Lifecycle+Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C316427422BBD009497A5 /* Lifecycle+Title.swift */; };
 		1D61304F843D44F002D05AEF /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176F3A31F864DAC55782333E /* Constants.swift */; };
 		276AF12532733ED2804B89C3 /* Color+Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6044A10B85101A31A3F2C45 /* Color+Application.swift */; };
 		31828B72443073F0960CF05E /* Pods_CustomDynamicFontTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9E2770C1198EAAEF04C4A72 /* Pods_CustomDynamicFontTests.framework */; };
@@ -121,6 +124,9 @@
 		096C3131273E18B6009497A5 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = "<group>"; };
 		09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectOSViewModelSpec.swift; sourceTree = "<group>"; };
 		096C3133273E293F009497A5 /* UIStackView+Subviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Subviews.swift"; sourceTree = "<group>"; };
+		096C31602742296E009497A5 /* UIKitViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitViewModel.swift; sourceTree = "<group>"; };
+		096C316227422B88009497A5 /* Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lifecycle.swift; sourceTree = "<group>"; };
+		096C316427422BBD009497A5 /* Lifecycle+Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Lifecycle+Title.swift"; sourceTree = "<group>"; };
 		176F3A31F864DAC55782333E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		181E6FF11063BAB9ED9D2AFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		21E833D795621A259CC50EC4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -276,6 +282,8 @@
 			isa = PBXGroup;
 			children = (
 				094CFCD9273BB2BE00C3A3AD /* IOS11UIKitViewController.swift */,
+				096C31602742296E009497A5 /* UIKitViewModel.swift */,
+				096C316427422BBD009497A5 /* Lifecycle+Title.swift */,
 			);
 			path = iOS11UIKit;
 			sourceTree = "<group>";
@@ -714,6 +722,7 @@
 			isa = PBXGroup;
 			children = (
 				094CFCAD2739099800C3A3AD /* OSVersion.swift */,
+				096C316227422B88009497A5 /* Lifecycle.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -1235,14 +1244,17 @@
 				DFE85932867F7C3D6C4E4E64 /* NetworkAPI.swift in Sources */,
 				096C3132273E18B6009497A5 /* R.generated.swift in Sources */,
 				094CFCA82738F42F00C3A3AD /* SelectOSViewController.swift in Sources */,
+				096C316527422BBD009497A5 /* Lifecycle+Title.swift in Sources */,
 				094CFCAE2739099800C3A3AD /* OSVersion.swift in Sources */,
 				EEB8EAE9F8C808D3B65E9B18 /* UseCaseFactoryProtocol.swift in Sources */,
+				096C31612742296E009497A5 /* UIKitViewModel.swift in Sources */,
 				094CFCA52738ED3300C3A3AD /* MainNavigationController.swift in Sources */,
 				094CFCA22738D68400C3A3AD /* ZenOldMincho.swift in Sources */,
 				82732721B0C0E075702FAE4B /* Navigator+Scene.swift in Sources */,
 				54DFC2996D364B99101BB9CE /* Navigator+Transition.swift in Sources */,
 				D11A849720B1157FEBECD912 /* Navigator.swift in Sources */,
 				094CFCDA273BB2BE00C3A3AD /* IOS11UIKitViewController.swift in Sources */,
+				096C316327422B88009497A5 /* Lifecycle.swift in Sources */,
 				65AD5E1D799921BD069C2B2A /* Optional+Unwrap.swift in Sources */,
 				276AF12532733ED2804B89C3 /* Color+Application.swift in Sources */,
 				096C3134273E293F009497A5 /* UIStackView+Subviews.swift in Sources */,

--- a/CustomDynamicFont.xcodeproj/project.pbxproj
+++ b/CustomDynamicFont.xcodeproj/project.pbxproj
@@ -24,11 +24,12 @@
 		094CFCDC273BB2CD00C3A3AD /* IOS10ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094CFCDB273BB2CD00C3A3AD /* IOS10ViewController.swift */; };
 		096C312C273E177F009497A5 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 096C312E273E177F009497A5 /* Localizable.strings */; };
 		096C3132273E18B6009497A5 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C3131273E18B6009497A5 /* R.generated.swift */; };
-		09B254B6274281E800D3E7F8 /* SelectOSViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */; };
 		096C3134273E293F009497A5 /* UIStackView+Subviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C3133273E293F009497A5 /* UIStackView+Subviews.swift */; };
 		096C31612742296E009497A5 /* UIKitViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C31602742296E009497A5 /* UIKitViewModel.swift */; };
 		096C316327422B88009497A5 /* Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C316227422B88009497A5 /* Lifecycle.swift */; };
 		096C316527422BBD009497A5 /* Lifecycle+Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C316427422BBD009497A5 /* Lifecycle+Title.swift */; };
+		09A81ECF2744B7B3008CBEBD /* UIKitViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */; };
+		09B254B6274281E800D3E7F8 /* SelectOSViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */; };
 		1D61304F843D44F002D05AEF /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176F3A31F864DAC55782333E /* Constants.swift */; };
 		276AF12532733ED2804B89C3 /* Color+Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6044A10B85101A31A3F2C45 /* Color+Application.swift */; };
 		31828B72443073F0960CF05E /* Pods_CustomDynamicFontTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9E2770C1198EAAEF04C4A72 /* Pods_CustomDynamicFontTests.framework */; };
@@ -122,11 +123,12 @@
 		094CFCDB273BB2CD00C3A3AD /* IOS10ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS10ViewController.swift; sourceTree = "<group>"; };
 		096C312D273E177F009497A5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		096C3131273E18B6009497A5 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = "<group>"; };
-		09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectOSViewModelSpec.swift; sourceTree = "<group>"; };
 		096C3133273E293F009497A5 /* UIStackView+Subviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Subviews.swift"; sourceTree = "<group>"; };
 		096C31602742296E009497A5 /* UIKitViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitViewModel.swift; sourceTree = "<group>"; };
 		096C316227422B88009497A5 /* Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lifecycle.swift; sourceTree = "<group>"; };
 		096C316427422BBD009497A5 /* Lifecycle+Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Lifecycle+Title.swift"; sourceTree = "<group>"; };
+		09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitViewModelSpec.swift; sourceTree = "<group>"; };
+		09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectOSViewModelSpec.swift; sourceTree = "<group>"; };
 		176F3A31F864DAC55782333E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		181E6FF11063BAB9ED9D2AFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		21E833D795621A259CC50EC4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -310,6 +312,14 @@
 				096C3131273E18B6009497A5 /* R.generated.swift */,
 			);
 			path = R.swift;
+			sourceTree = "<group>";
+		};
+		09A81ECC2744B687008CBEBD /* IOS11UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */,
+			);
+			path = IOS11UIKit;
 			sourceTree = "<group>";
 		};
 		09B254B327427FCD00D3E7F8 /* SelectOS */ = {
@@ -507,6 +517,7 @@
 		6E103246A8276C4EEE1070D4 /* Specs */ = {
 			isa = PBXGroup;
 			children = (
+				09A81ECC2744B687008CBEBD /* IOS11UIKit */,
 				09B254B327427FCD00D3E7F8 /* SelectOS */,
 				AA99693992730C85AAAC9459 /* Supports */,
 			);
@@ -1275,6 +1286,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				09A81ECF2744B7B3008CBEBD /* UIKitViewModelSpec.swift in Sources */,
 				F02FB15953EC1EC78DD2BD50 /* AutoMockable.generated.swift in Sources */,
 				09B254B6274281E800D3E7F8 /* SelectOSViewModelSpec.swift in Sources */,
 				31A559868822CE12B3650D75 /* OptionalUnwrapSpec.swift in Sources */,

--- a/CustomDynamicFont/Resources/Localizations/en.lproj/Localizable.strings
+++ b/CustomDynamicFont/Resources/Localizations/en.lproj/Localizable.strings
@@ -10,6 +10,6 @@
 "selectos.navigation.title" = "Dynamic Font";
 "osversion.ios10.title" = "iOS 10";
 "osversion.ios11.title" = "iOS >=11";
-"ios11uikit.versionlabel.title" = "iOS 11";
 "ios11uikit.commentlabel.title" = "A demo from NimbleHQ";
 "ios11uikit.lifecyclelabel.title" = "UIKit";
+"ios12swiftui.lifecyclelabel.title" = "SwiftUI";

--- a/CustomDynamicFont/Sources/Domain/Entities/Lifecycle.swift
+++ b/CustomDynamicFont/Sources/Domain/Entities/Lifecycle.swift
@@ -8,6 +8,6 @@
 
 enum Lifecycle {
 
-    case uikit
-    case swiftui
+    case uiKit
+    case swiftUI
 }

--- a/CustomDynamicFont/Sources/Domain/Entities/Lifecycle.swift
+++ b/CustomDynamicFont/Sources/Domain/Entities/Lifecycle.swift
@@ -1,0 +1,13 @@
+//
+//  Lifecycle.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 15/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+enum Lifecycle {
+
+    case uikit
+    case swiftui
+}

--- a/CustomDynamicFont/Sources/Injection/Resolver+Presentation.swift
+++ b/CustomDynamicFont/Sources/Injection/Resolver+Presentation.swift
@@ -17,6 +17,7 @@ extension Resolver {
 
     private static func registerViewModels() {
         register(SelectOSViewModelProtocol.self) { SelectOSViewModel() }
+        register(UIKitViewModelProtocol.self) { UIKitViewModel() }
     }
 
     private static func registerNavigation() {

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Nimble. All rights reserved.
 //
 
+import Resolver
 import RxSwift
 import UIKit
 
@@ -22,16 +23,7 @@ final class IOS11UIKitViewController: UIViewController {
 
     private let disposeBag = DisposeBag()
 
-    private let viewModel: UIKitViewModelProtocol
-
-    init(viewModel: UIKitViewModelProtocol) {
-        self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    @Injected private var viewModel: UIKitViewModelProtocol
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Nimble. All rights reserved.
 //
 
+import RxSwift
 import UIKit
 
 final class IOS11UIKitViewController: UIViewController {
@@ -19,10 +20,24 @@ final class IOS11UIKitViewController: UIViewController {
     private let contentView = UIView()
     private let stackView = UIStackView()
 
+    private let disposeBag = DisposeBag()
+
+    private let viewModel: UIKitViewModelProtocol
+
+    init(viewModel: UIKitViewModelProtocol) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpLayout()
         setUpViews()
+        bindViewModel()
     }
 }
 
@@ -84,11 +99,19 @@ extension IOS11UIKitViewController {
         lifecycleLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body)
         commentLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .footnote)
 
-        fontNameLabel.text = "Font Name" // TODO: Localize in integration
-        versionLabel.text = R.string.localizable.ios11uikitVersionlabelTitle()
-        lifecycleLabel.text = R.string.localizable.ios11uikitLifecyclelabelTitle()
-        commentLabel.text = R.string.localizable.ios11uikitCommentlabelTitle()
-
         imageView.image = R.image.color_Rectangle()
+    }
+
+    private func bindViewModel() {
+        viewModel.output.title.drive(rx.title)
+            .disposed(by: disposeBag)
+        viewModel.output.fontName.drive(fontNameLabel.rx.text)
+            .disposed(by: disposeBag)
+        viewModel.output.osVersion.drive(versionLabel.rx.text)
+            .disposed(by: disposeBag)
+        viewModel.output.lifecycle.drive(lifecycleLabel.rx.text)
+            .disposed(by: disposeBag)
+        viewModel.output.caption.drive(commentLabel.rx.text)
+            .disposed(by: disposeBag)
     }
 }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/Lifecycle+Title.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/Lifecycle+Title.swift
@@ -1,0 +1,19 @@
+//
+//  Lifecycle+Title.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 15/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+extension Lifecycle {
+
+    func title() -> String {
+        switch self {
+        case .uikit:
+            return R.string.localizable.ios11uikitLifecyclelabelTitle()
+        case .swiftui:
+            return R.string.localizable.ios12swiftuiLifecyclelabelTitle()
+        }
+    }
+}

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/Lifecycle+Title.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/Lifecycle+Title.swift
@@ -10,9 +10,9 @@ extension Lifecycle {
 
     func title() -> String {
         switch self {
-        case .uikit:
+        case .uiKit:
             return R.string.localizable.ios11uikitLifecyclelabelTitle()
-        case .swiftui:
+        case .swiftUI:
             return R.string.localizable.ios12swiftuiLifecyclelabelTitle()
         }
     }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
@@ -48,7 +48,7 @@ final class UIKitViewModel: UIKitViewModelProtocol {
         title = Driver.just(OSVersion.iosGreaterOrEqualTo11.title())
         osVersion = Driver.just(OSVersion.iosGreaterOrEqualTo11.title())
         fontName = Driver.just(UIFont.ZenOldMincho.regular.fontName())
-        lifecycle = Driver.just(Lifecycle.uikit.title())
+        lifecycle = Driver.just(Lifecycle.uiKit.title())
         caption = Driver.just(R.string.localizable.ios11uikitCommentlabelTitle())
     }
 }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  UIKitViewModel.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 15/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+import Foundation
+import Resolver
+import RxCocoa
+import RxSwift
+
+// sourcery: AutoMockable
+protocol UIKitViewModelInput {}
+
+// sourcery: AutoMockable
+protocol UIKitViewModelOutput {
+
+    var title: Driver<String> { get }
+    var osVersion: Driver<String> { get }
+    var fontName: Driver<String> { get }
+    var lifecycle: Driver<String> { get }
+    var caption: Driver<String> { get }
+}
+
+// sourcery: AutoMockable
+protocol UIKitViewModelProtocol: AnyObject {
+
+    var input: UIKitViewModelInput { get }
+    var output: UIKitViewModelOutput { get }
+}
+
+final class UIKitViewModel: UIKitViewModelProtocol {
+
+    var title: Driver<String>
+    var osVersion: Driver<String>
+    var fontName: Driver<String>
+    var lifecycle: Driver<String>
+    var caption: Driver<String>
+
+    var input: UIKitViewModelInput { self }
+    var output: UIKitViewModelOutput { self }
+
+    private let disposeBag = DisposeBag()
+
+    init() {
+        title = Driver.just(OSVersion.iosGreaterAndEqualTo11.title())
+        osVersion = Driver.just(OSVersion.iosGreaterAndEqualTo11.title())
+        fontName = Driver.just(UIFont.ZenOldMincho.regular.fontName())
+        lifecycle = Driver.just(Lifecycle.uikit.title())
+        caption = Driver.just(R.string.localizable.ios11uikitCommentlabelTitle())
+    }
+}
+
+// MARK: - UIKitViewModelInput
+
+extension UIKitViewModel: UIKitViewModelInput {}
+
+// MARK: - UIKitViewModelOutput
+
+extension UIKitViewModel: UIKitViewModelOutput {}

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
@@ -45,8 +45,8 @@ final class UIKitViewModel: UIKitViewModelProtocol {
     private let disposeBag = DisposeBag()
 
     init() {
-        title = Driver.just(OSVersion.iosGreaterAndEqualTo11.title())
-        osVersion = Driver.just(OSVersion.iosGreaterAndEqualTo11.title())
+        title = Driver.just(OSVersion.iosGreaterOrEqualTo11.title())
+        osVersion = Driver.just(OSVersion.iosGreaterOrEqualTo11.title())
         fontName = Driver.just(UIFont.ZenOldMincho.regular.fontName())
         lifecycle = Driver.just(Lifecycle.uikit.title())
         caption = Driver.just(R.string.localizable.ios11uikitCommentlabelTitle())

--- a/CustomDynamicFont/Sources/Presentation/Navigator/Navigator.swift
+++ b/CustomDynamicFont/Sources/Presentation/Navigator/Navigator.swift
@@ -25,7 +25,7 @@ final class Navigator {
         case .iOS11Tabbar:
             let tabbarController = UITabBarController()
             tabbarController.setViewControllers(
-                [IOS11UIKitViewController(), IOS12SwiftUIViewController()],
+                [IOS11UIKitViewController(viewModel: UIKitViewModel()), IOS12SwiftUIViewController()],
                 animated: false
             )
             return tabbarController

--- a/CustomDynamicFont/Sources/Presentation/Navigator/Navigator.swift
+++ b/CustomDynamicFont/Sources/Presentation/Navigator/Navigator.swift
@@ -25,7 +25,7 @@ final class Navigator {
         case .iOS11Tabbar:
             let tabbarController = UITabBarController()
             tabbarController.setViewControllers(
-                [IOS11UIKitViewController(viewModel: UIKitViewModel()), IOS12SwiftUIViewController()],
+                [IOS11UIKitViewController(), IOS12SwiftUIViewController()],
                 animated: false
             )
             return tabbarController

--- a/CustomDynamicFontTests/Sources/Specs/IOS11UIKit/UIKitViewModelSpec.swift
+++ b/CustomDynamicFontTests/Sources/Specs/IOS11UIKit/UIKitViewModelSpec.swift
@@ -1,0 +1,72 @@
+//
+//  UIKitViewModelSpec.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 17/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+// swiftlint:disable closure_body_length
+
+@testable import CustomDynamicFont
+import Nimble
+import Quick
+import Resolver
+import RxNimble
+import RxSwift
+import RxTest
+
+final class UIKitViewModelSpec: QuickSpec {
+
+    override func spec() {
+
+        var viewModel: UIKitViewModel!
+        var scheduler: TestScheduler!
+        var disposeBag: DisposeBag!
+
+        describe("a UIKitViewModel") {
+
+            beforeEach {
+                viewModel = UIKitViewModel()
+                scheduler = TestScheduler(initialClock: 0)
+                disposeBag = DisposeBag()
+            }
+
+            afterEach {
+                scheduler = nil
+            }
+
+            context("when Initialized") {
+
+                it("returns output with correct title") {
+                    expect(viewModel.output.title)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(0, OSVersion.iosGreaterOrEqualTo11.title()), .completed(0)]))
+                }
+
+                it("returns output with correct osVersion") {
+                    expect(viewModel.output.osVersion)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(0, OSVersion.iosGreaterOrEqualTo11.title()), .completed(0)]))
+                }
+
+                it("returns output with correct fontName") {
+                    expect(viewModel.output.fontName)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(0, UIFont.ZenOldMincho.regular.fontName()), .completed(0)]))
+                }
+
+                it("returns output with correct lifecycle") {
+                    expect(viewModel.output.lifecycle)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(0, Lifecycle.uiKit.title()), .completed(0)]))
+                }
+
+                it("returns output with correct caption") {
+                    expect(viewModel.output.caption)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(0, R.string.localizable.ios11uikitCommentlabelTitle()), .completed(0)]))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
close #14

## What happened

The following text is custom font **and** dynamic with device's settings.
- Bold title text "Font Name"
- Text "iOS 11"
- Text "UIKit"
- Caption text "A demo from NimbleHQ"
- "Font Name" should be the family name of the custom font.
 
## Insight

Create a viewmodel `UIKitViewModel` to share between iOS10 and 11.
 
## Proof Of Work
<img width=300 src="https://user-images.githubusercontent.com/6356137/141734394-64fd6200-bb4f-4744-9303-383fd0f335a4.png">



