### PR TITLE
[#19] [UI] As a user, I can see the iOS 11 UIKit Screen with Override Settings

### DIFF
--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
@@ -21,6 +21,14 @@ final class IOS11UIKitViewController: UIViewController {
     private let contentView = UIView()
     private let stackView = UIStackView()
 
+    private let overrideFontSectionLabel = UILabel()
+    private let overrideFontSegment = UISegmentedControl()
+    private let overrideFontSlider = UISlider()
+    private let overrideFontLabel = UILabel()
+    private let overrideFontScaleSectionLabel = UILabel()
+    private let overrideFontStackView = UIStackView()
+    private let overrideFontSliderStackView = UIStackView()
+
     private let disposeBag = DisposeBag()
 
     @Injected private var viewModel: UIKitViewModelProtocol
@@ -40,12 +48,28 @@ extension IOS11UIKitViewController {
     private func setUpLayout() {
         view.addSubview(scrollView)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(imageView, stackView)
+        contentView.addSubviews(
+            imageView,
+            stackView,
+            overrideFontStackView
+        )
         stackView.addArrangedSubviews(
             fontNameLabel,
             versionLabel,
             lifecycleLabel,
-            commentLabel
+            commentLabel,
+            overrideFontLabel,
+            overrideFontSegment
+        )
+
+        overrideFontStackView.addArrangedSubviews(
+            overrideFontScaleSectionLabel,
+            overrideFontSliderStackView
+        )
+
+        overrideFontSliderStackView.addArrangedSubviews(
+            overrideFontSlider,
+            overrideFontSectionLabel
         )
 
         scrollView.snp.makeConstraints {
@@ -65,7 +89,20 @@ extension IOS11UIKitViewController {
 
         stackView.snp.makeConstraints {
             $0.top.equalTo(imageView.snp.bottom).offset(20.0)
+            $0.leading.trailing.equalToSuperview().inset(20.0)
+        }
+
+        overrideFontStackView.snp.makeConstraints {
+            $0.top.equalTo(stackView.snp.bottom).offset(20.0)
             $0.leading.trailing.bottom.equalToSuperview().inset(20.0)
+        }
+
+        overrideFontLabel.snp.makeConstraints {
+            $0.width.equalToSuperview()
+        }
+
+        overrideFontSegment.snp.makeConstraints {
+            $0.width.equalToSuperview()
         }
     }
 
@@ -75,6 +112,12 @@ extension IOS11UIKitViewController {
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 8.0
+
+        overrideFontStackView.axis = .vertical
+        overrideFontStackView.distribution = .fill
+        overrideFontStackView.spacing = 8.0
+
+        overrideFontSliderStackView.spacing = 8.0
 
         fontNameLabel.textAlignment = .center
         versionLabel.textAlignment = .center
@@ -90,6 +133,16 @@ extension IOS11UIKitViewController {
         versionLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body)
         lifecycleLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body)
         commentLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .footnote)
+
+        overrideFontLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body)
+        overrideFontSectionLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body)
+        overrideFontScaleSectionLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body)
+        // TODO: Replace in integration
+        overrideFontLabel.text = "placeholder"
+        overrideFontSectionLabel.text = "placeholder"
+        overrideFontScaleSectionLabel.text = "placeholder"
+        overrideFontSegment.insertSegment(withTitle: "1", at: 0, animated: false)
+        overrideFontSegment.insertSegment(withTitle: "2", at: 1, animated: false)
 
         imageView.image = R.image.color_Rectangle()
     }


### PR DESCRIPTION
close #19 

## What happened

The iOS 11 UIKit screen should include:
- Image and text section.
- Label "Override System Font Size".
- On/Off Toggle
- Label "Override Font Size".
- Slider for the font size.
- Font size indicator. 
 
## Insight

Just the UI.
 
## Proof Of Work

<img width=300 src="https://user-images.githubusercontent.com/6356137/141734551-a24b6a8a-4081-4451-9469-9d7b89d41835.png">




