### PR TITLE
[#20] [Integrate] As a user, I can see the iOS 11 UIKit Screen with Override Settings

### DIFF
--- a/CustomDynamicFont.xcodeproj/project.pbxproj
+++ b/CustomDynamicFont.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		09A81ECF2744B7B3008CBEBD /* UIKitViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */; };
 		09B254B6274281E800D3E7F8 /* SelectOSViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */; };
 		09B254B02742504500D3E7F8 /* UIContentSizeCategory+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */; };
+		09B254B2274273B700D3E7F8 /* UIView+AdjustFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B1274273B600D3E7F8 /* UIView+AdjustFont.swift */; };
 		1D61304F843D44F002D05AEF /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176F3A31F864DAC55782333E /* Constants.swift */; };
 		276AF12532733ED2804B89C3 /* Color+Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6044A10B85101A31A3F2C45 /* Color+Application.swift */; };
 		31828B72443073F0960CF05E /* Pods_CustomDynamicFontTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9E2770C1198EAAEF04C4A72 /* Pods_CustomDynamicFontTests.framework */; };
@@ -131,6 +132,7 @@
 		09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitViewModelSpec.swift; sourceTree = "<group>"; };
 		09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectOSViewModelSpec.swift; sourceTree = "<group>"; };
 		09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentSizeCategory+Label.swift"; sourceTree = "<group>"; };
+		09B254B1274273B600D3E7F8 /* UIView+AdjustFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AdjustFont.swift"; sourceTree = "<group>"; };
 		176F3A31F864DAC55782333E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		181E6FF11063BAB9ED9D2AFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		21E833D795621A259CC50EC4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -512,6 +514,7 @@
 			children = (
 				A6044A10B85101A31A3F2C45 /* Color+Application.swift */,
 				096C3133273E293F009497A5 /* UIStackView+Subviews.swift */,
+				09B254B1274273B600D3E7F8 /* UIView+AdjustFont.swift */,
 				5A83514AFAB04EF8CE36969D /* UIView+Subviews.swift */,
 			);
 			path = UIKit;
@@ -1248,6 +1251,7 @@
 				094CFCA027352C7F00C3A3AD /* UIFont+CustomFont.swift in Sources */,
 				D075ABFE0F1A55DA4716271B /* Constants+API.swift in Sources */,
 				1D61304F843D44F002D05AEF /* Constants.swift in Sources */,
+				09B254B2274273B700D3E7F8 /* UIView+AdjustFont.swift in Sources */,
 				7ED2A47D73BC9D924DD97243 /* NetworkAPIError.swift in Sources */,
 				A1FBAF4E0002A275142863AB /* NetworkAPIProtocol.swift in Sources */,
 				094CFCB02739137F00C3A3AD /* OSVersion+Title.swift in Sources */,

--- a/CustomDynamicFont.xcodeproj/project.pbxproj
+++ b/CustomDynamicFont.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		096C316527422BBD009497A5 /* Lifecycle+Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C316427422BBD009497A5 /* Lifecycle+Title.swift */; };
 		09A81ECF2744B7B3008CBEBD /* UIKitViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */; };
 		09B254B6274281E800D3E7F8 /* SelectOSViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */; };
+		09B254B02742504500D3E7F8 /* UIContentSizeCategory+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */; };
 		1D61304F843D44F002D05AEF /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176F3A31F864DAC55782333E /* Constants.swift */; };
 		276AF12532733ED2804B89C3 /* Color+Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6044A10B85101A31A3F2C45 /* Color+Application.swift */; };
 		31828B72443073F0960CF05E /* Pods_CustomDynamicFontTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9E2770C1198EAAEF04C4A72 /* Pods_CustomDynamicFontTests.framework */; };
@@ -129,6 +130,7 @@
 		096C316427422BBD009497A5 /* Lifecycle+Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Lifecycle+Title.swift"; sourceTree = "<group>"; };
 		09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitViewModelSpec.swift; sourceTree = "<group>"; };
 		09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectOSViewModelSpec.swift; sourceTree = "<group>"; };
+		09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentSizeCategory+Label.swift"; sourceTree = "<group>"; };
 		176F3A31F864DAC55782333E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		181E6FF11063BAB9ED9D2AFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		21E833D795621A259CC50EC4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 				094CFCD9273BB2BE00C3A3AD /* IOS11UIKitViewController.swift */,
 				096C31602742296E009497A5 /* UIKitViewModel.swift */,
 				096C316427422BBD009497A5 /* Lifecycle+Title.swift */,
+				09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */,
 			);
 			path = iOS11UIKit;
 			sourceTree = "<group>";
@@ -1261,6 +1264,7 @@
 				096C31612742296E009497A5 /* UIKitViewModel.swift in Sources */,
 				094CFCA52738ED3300C3A3AD /* MainNavigationController.swift in Sources */,
 				094CFCA22738D68400C3A3AD /* ZenOldMincho.swift in Sources */,
+				09B254B02742504500D3E7F8 /* UIContentSizeCategory+Label.swift in Sources */,
 				82732721B0C0E075702FAE4B /* Navigator+Scene.swift in Sources */,
 				54DFC2996D364B99101BB9CE /* Navigator+Transition.swift in Sources */,
 				D11A849720B1157FEBECD912 /* Navigator.swift in Sources */,

--- a/CustomDynamicFont/Resources/Localizations/en.lproj/Localizable.strings
+++ b/CustomDynamicFont/Resources/Localizations/en.lproj/Localizable.strings
@@ -13,3 +13,11 @@
 "ios11uikit.commentlabel.title" = "A demo from NimbleHQ";
 "ios11uikit.lifecyclelabel.title" = "UIKit";
 "ios12swiftui.lifecyclelabel.title" = "SwiftUI";
+"ios11uikit.overrideFontTitle.title" = "Override System Font Size";
+"ios11uikit.overrideFontSegmentOptions.on" = "On";
+"ios11uikit.overrideFontSegmentOptions.off" = "Off";
+"ios11uikit.overrideFontScaleTitle.title" = "Override Font Size";
+"overridefontsize.small.label" = "SM";
+"overridefontsize.normal.label" = "MD";
+"overridefontsize.large.label" = "LG";
+"overridefontsize.extraLarge.label" = "XL";

--- a/CustomDynamicFont/Sources/Presentation/CustomFont/UIFont+CustomFont.swift
+++ b/CustomDynamicFont/Sources/Presentation/CustomFont/UIFont+CustomFont.swift
@@ -16,13 +16,21 @@ protocol DynamicFont {
 
 extension UIFont {
 
-    class func customFont(_ font: DynamicFont, forTextStyle style: UIFont.TextStyle) -> UIFont? {
+    class func customFont(
+        _ font: DynamicFont,
+        forTextStyle style: UIFont.TextStyle,
+        overrideFontSize: UIContentSizeCategory? = nil
+    ) -> UIFont? {
         guard let customFont = UIFont(name: font.fontName(), size: font.fontSize(style: style)) else { return nil }
         let metrics = UIFontMetrics(forTextStyle: style)
         let scaledFont: UIFont
 
         if #available(iOS 11.0, *) {
-            scaledFont = metrics.scaledFont(for: customFont)
+            scaledFont = metrics.scaledFont(
+                for: customFont, compatibleWith: UITraitCollection(
+                    preferredContentSizeCategory: overrideFontSize ?? .unspecified
+                )
+            )
         } else {
             // TODO: Implement iOS 10 font scaling logic
             scaledFont = customFont

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
@@ -143,7 +143,7 @@ extension IOS11UIKitViewController {
             overrideFontLabel,
             overrideFontSectionLabel,
             overrideFontScaleSectionLabel,
-            on: fontSize == nil
+            isOn: fontSize == nil
         )
         fontNameLabel.font = .customFont(UIFont.ZenOldMincho.bold, forTextStyle: .headline, overrideFontSize: fontSize)
         versionLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body, overrideFontSize: fontSize)

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/IOS11UIKitViewController.swift
@@ -135,6 +135,16 @@ extension IOS11UIKitViewController {
     }
 
     func setUpFont(fontSize: UIContentSizeCategory?) {
+        UIView.setAutoAdjustFont(
+            fontNameLabel,
+            versionLabel,
+            lifecycleLabel,
+            commentLabel,
+            overrideFontLabel,
+            overrideFontSectionLabel,
+            overrideFontScaleSectionLabel,
+            on: fontSize == nil
+        )
         fontNameLabel.font = .customFont(UIFont.ZenOldMincho.bold, forTextStyle: .headline, overrideFontSize: fontSize)
         versionLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body, overrideFontSize: fontSize)
         lifecycleLabel.font = .customFont(UIFont.ZenOldMincho.regular, forTextStyle: .body, overrideFontSize: fontSize)

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIContentSizeCategory+Label.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIContentSizeCategory+Label.swift
@@ -1,0 +1,26 @@
+//
+//  UIContentSizeCategory+Label.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 15/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+import UIKit
+
+extension UIContentSizeCategory {
+
+    func label() -> String {
+        switch self {
+        case .small:
+            return R.string.localizable.overridefontsizeSmallLabel()
+        case .medium:
+            return R.string.localizable.overridefontsizeNormalLabel()
+        case .large:
+            return R.string.localizable.overridefontsizeLargeLabel()
+        case .extraLarge:
+            return R.string.localizable.overridefontsizeExtraLargeLabel()
+        default: return ""
+        }
+    }
+}

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
@@ -12,7 +12,10 @@ import RxCocoa
 import RxSwift
 
 // sourcery: AutoMockable
-protocol UIKitViewModelInput {}
+protocol UIKitViewModelInput {
+
+    func overrideFontSize(_ index: Int)
+}
 
 // sourcery: AutoMockable
 protocol UIKitViewModelOutput {
@@ -22,6 +25,14 @@ protocol UIKitViewModelOutput {
     var fontName: Driver<String> { get }
     var lifecycle: Driver<String> { get }
     var caption: Driver<String> { get }
+    var overrideFontTitle: Driver<String> { get }
+    var overrideFontIsHidding: Driver<Bool> { get }
+    var overrideFontScaleTitle: Driver<String> { get }
+    var overrideFontSegmentOptions: Driver<[String]> { get }
+    var overrideFontOnValue: BehaviorRelay<Int> { get }
+    var overrideFontSliderOptions: Driver<[UIContentSizeCategory]> { get }
+    var overrideFontSize: Driver<UIContentSizeCategory?> { get }
+    var overrideFontSizeText: Driver<String> { get }
 }
 
 // sourcery: AutoMockable
@@ -38,6 +49,20 @@ final class UIKitViewModel: UIKitViewModelProtocol {
     var fontName: Driver<String>
     var lifecycle: Driver<String>
     var caption: Driver<String>
+    var overrideFontTitle: Driver<String>
+    var overrideFontIsHidding: Driver<Bool>
+    var overrideFontScaleTitle: Driver<String>
+    var overrideFontSegmentOptions: Driver<[String]>
+    var overrideFontOnValue: BehaviorRelay<Int>
+    var overrideFontSliderOptions: Driver<[UIContentSizeCategory]>
+    var overrideFontSize: Driver<UIContentSizeCategory?>
+    var overrideFontSizeText: Driver<String>
+
+    private let overrideFontTrigger = PublishRelay<Bool>()
+    private let overrideFontSizeTrigger = PublishRelay<UIContentSizeCategory?>()
+    private let overrideFontSizes: [UIContentSizeCategory] = [.small, .medium, .large, .extraLarge]
+
+    private var recentOverrideFontSize: UIContentSizeCategory = .medium
 
     var input: UIKitViewModelInput { self }
     var output: UIKitViewModelOutput { self }
@@ -50,12 +75,42 @@ final class UIKitViewModel: UIKitViewModelProtocol {
         fontName = Driver.just(UIFont.ZenOldMincho.regular.fontName())
         lifecycle = Driver.just(Lifecycle.uiKit.title())
         caption = Driver.just(R.string.localizable.ios11uikitCommentlabelTitle())
+        overrideFontTitle = Driver.just(R.string.localizable.ios11uikitOverrideFontTitleTitle())
+        overrideFontScaleTitle = Driver.just(R.string.localizable.ios11uikitOverrideFontScaleTitleTitle())
+        overrideFontSegmentOptions = Driver.just(
+            [
+                R.string.localizable.ios11uikitOverrideFontSegmentOptionsOn(),
+                R.string.localizable.ios11uikitOverrideFontSegmentOptionsOff()
+            ]
+        )
+        overrideFontOnValue = BehaviorRelay<Int>(value: 0)
+        overrideFontIsHidding = overrideFontOnValue.map { $0 != 1 }.asDriver(onErrorJustReturn: false)
+        overrideFontSliderOptions = Driver.just(overrideFontSizes)
+        overrideFontSize = overrideFontSizeTrigger.asDriver(onErrorJustReturn: .unspecified)
+        overrideFontSizeText = overrideFontSizeTrigger
+            .compactMap { $0?.label() }
+            .asDriver(onErrorJustReturn: "")
+        overrideFontOnValue.withUnretained(self)
+            .subscribe { owner, value in
+                if value == 0 {
+                    owner.overrideFontSizeTrigger.accept(nil)
+                } else {
+                    owner.overrideFontSizeTrigger.accept(owner.recentOverrideFontSize)
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }
 
 // MARK: - UIKitViewModelInput
 
-extension UIKitViewModel: UIKitViewModelInput {}
+extension UIKitViewModel: UIKitViewModelInput {
+
+    func overrideFontSize(_ index: Int) {
+        recentOverrideFontSize = overrideFontSizes[index]
+        overrideFontSizeTrigger.accept(overrideFontSizes[index])
+    }
+}
 
 // MARK: - UIKitViewModelOutput
 

--- a/CustomDynamicFont/Sources/Supports/Extensions/UIKit/UIView+AdjustFont.swift
+++ b/CustomDynamicFont/Sources/Supports/Extensions/UIKit/UIView+AdjustFont.swift
@@ -1,0 +1,21 @@
+//
+//  UIView+AdjustFont.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 15/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+
+    static func setAutoAdjustFont(_ views: UIView..., on: Bool = true) {
+        views.forEach {
+            if let view = $0 as? UILabel {
+                view.adjustsFontForContentSizeCategory = on
+            }
+        }
+    }
+}
+

--- a/CustomDynamicFont/Sources/Supports/Extensions/UIKit/UIView+AdjustFont.swift
+++ b/CustomDynamicFont/Sources/Supports/Extensions/UIKit/UIView+AdjustFont.swift
@@ -10,12 +10,11 @@ import UIKit
 
 extension UIView {
 
-    static func setAutoAdjustFont(_ views: UIView..., on: Bool = true) {
+    static func setAutoAdjustFont(_ views: UIView..., isOn: Bool = true) {
         views.forEach {
             if let view = $0 as? UILabel {
-                view.adjustsFontForContentSizeCategory = on
+                view.adjustsFontForContentSizeCategory = isOn
             }
         }
     }
 }
-

--- a/CustomDynamicFontTests/Sources/Specs/IOS11UIKit/UIKitViewModelSpec.swift
+++ b/CustomDynamicFontTests/Sources/Specs/IOS11UIKit/UIKitViewModelSpec.swift
@@ -5,7 +5,7 @@
 //  Created by Bliss on 17/11/21.
 //  Copyright © 2021 Nimble. All rights reserved.
 //
-// swiftlint:disable closure_body_length
+// swiftlint:disable closure_body_length function_body_length
 
 @testable import CustomDynamicFont
 import Nimble
@@ -65,6 +65,94 @@ final class UIKitViewModelSpec: QuickSpec {
                     expect(viewModel.output.caption)
                         .events(scheduler: scheduler, disposeBag: disposeBag)
                         .to(equal([.next(0, R.string.localizable.ios11uikitCommentlabelTitle()), .completed(0)]))
+                }
+
+                it("returns output with correct overrideFontTitle") {
+                    expect(viewModel.output.overrideFontTitle)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(0, R.string.localizable.ios11uikitOverrideFontTitleTitle()), .completed(0)]))
+                }
+
+                it("returns output with correct overrideFontScaleTitle") {
+                    expect(viewModel.output.overrideFontScaleTitle)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([
+                            .next(0, R.string.localizable.ios11uikitOverrideFontScaleTitleTitle()),
+                            .completed(0)
+                        ]))
+                }
+
+                it("returns output with correct overrideFontSegmentOptions") {
+                    expect(viewModel.output.overrideFontSegmentOptions)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([
+                            .next(
+                                0,
+                                [
+                                    R.string.localizable.ios11uikitOverrideFontSegmentOptionsOn(),
+                                    R.string.localizable.ios11uikitOverrideFontSegmentOptionsOff()
+                                ]
+                            ),
+                            .completed(0)
+                        ]))
+                }
+
+                it("returns output with correct overrideFontSliderOptions") {
+                    expect(viewModel.output.overrideFontSliderOptions)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(0, [.small, .medium, .large, .extraLarge]), .completed(0)]))
+                }
+            }
+
+            context("when output overrideFontOnValue is changed") {
+
+                it("set correct value to output overrideFontIsHidding") {
+                    scheduler.scheduleAt(50) {
+                        viewModel.output.overrideFontOnValue.accept(1)
+                    }
+                    scheduler.scheduleAt(100) {
+                        viewModel.output.overrideFontOnValue.accept(0)
+                    }
+
+                    expect(viewModel.output.overrideFontIsHidding)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(0, true), .next(50, false), .next(100, true)]))
+                }
+
+                it("set correct value to output overrideFontSize") {
+                    scheduler.scheduleAt(50) {
+                        viewModel.output.overrideFontOnValue.accept(1)
+                    }
+                    scheduler.scheduleAt(100) {
+                        viewModel.output.overrideFontOnValue.accept(0)
+                    }
+
+                    expect(viewModel.output.overrideFontSize)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(50, .medium), .next(100, nil)]))
+                }
+            }
+
+            context("when input overrideFontSize is called") {
+
+                it("returns output overrideFontSize with correct value") {
+                    scheduler.scheduleAt(50) {
+                        viewModel.input.overrideFontSize(0)
+                    }
+
+                    expect(viewModel.output.overrideFontSize)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(50, .small)]))
+                }
+
+                it("returns output overrideFontSizeText with correct value") {
+                    scheduler.scheduleAt(50) {
+                        viewModel.input.overrideFontSize(0)
+                    }
+
+                    expect(viewModel.output.overrideFontSizeText)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(50, UIContentSizeCategory.small.label())]))
                 }
             }
         }


### PR DESCRIPTION
close #20 

## What happened


When the On/Off toggle is tap show when on and hide when off the following:
- Label "Override Font Size".
- Slider for the font size.
- Font size indicator. 

Screen's font size changes when the toggle is switched.
- When on, override system font size with the slider's setting.
- When off, use system font size.

Slider has four values: small, regular, large, x-large.

Slider should change the screen's font size.

Font size indicator updates with value from the slider.
 
## Insight

Add override font settings to ViewModel.
 
## Proof Of Work

https://user-images.githubusercontent.com/6356137/141771965-19a4fb6c-75d8-4648-8b4b-cd75d8727370.mp4



