### PR TITLE
[#10] [#12] [Integrate] As a user, I can see the iOS 10 Screen with Dynamic Custom Font

### DIFF
--- a/CustomDynamicFont.xcodeproj/project.pbxproj
+++ b/CustomDynamicFont.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		09A81EF727456961008CBEBD /* DynamicFontController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81EF627456961008CBEBD /* DynamicFontController.swift */; };
 		09A81EF927456C96008CBEBD /* IOS10DynamicFontController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81EF827456C96008CBEBD /* IOS10DynamicFontController.swift */; };
 		09A81EFB2745DE5D008CBEBD /* UIKitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81EFA2745DE5D008CBEBD /* UIKitView.swift */; };
+		09A81EFD2745E632008CBEBD /* UIFont+DynamicFontIOS10.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81EFC2745E632008CBEBD /* UIFont+DynamicFontIOS10.swift */; };
 		09B254B02742504500D3E7F8 /* UIContentSizeCategory+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */; };
 		09B254B2274273B700D3E7F8 /* UIView+AdjustFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B1274273B600D3E7F8 /* UIView+AdjustFont.swift */; };
 		09B254B6274281E800D3E7F8 /* SelectOSViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */; };
@@ -136,6 +137,7 @@
 		09A81EF627456961008CBEBD /* DynamicFontController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFontController.swift; sourceTree = "<group>"; };
 		09A81EF827456C96008CBEBD /* IOS10DynamicFontController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS10DynamicFontController.swift; sourceTree = "<group>"; };
 		09A81EFA2745DE5D008CBEBD /* UIKitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitView.swift; sourceTree = "<group>"; };
+		09A81EFC2745E632008CBEBD /* UIFont+DynamicFontIOS10.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+DynamicFontIOS10.swift"; sourceTree = "<group>"; };
 		09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentSizeCategory+Label.swift"; sourceTree = "<group>"; };
 		09B254B1274273B600D3E7F8 /* UIView+AdjustFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AdjustFont.swift"; sourceTree = "<group>"; };
 		09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectOSViewModelSpec.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				094CFC9F27352C7F00C3A3AD /* UIFont+CustomFont.swift */,
+				09A81EFC2745E632008CBEBD /* UIFont+DynamicFontIOS10.swift */,
 				094CFCA12738D68400C3A3AD /* ZenOldMincho.swift */,
 			);
 			path = CustomFont;
@@ -1279,6 +1282,7 @@
 				094CFCA52738ED3300C3A3AD /* MainNavigationController.swift in Sources */,
 				094CFCA22738D68400C3A3AD /* ZenOldMincho.swift in Sources */,
 				09B254B02742504500D3E7F8 /* UIContentSizeCategory+Label.swift in Sources */,
+				09A81EFD2745E632008CBEBD /* UIFont+DynamicFontIOS10.swift in Sources */,
 				82732721B0C0E075702FAE4B /* Navigator+Scene.swift in Sources */,
 				09A81EF927456C96008CBEBD /* IOS10DynamicFontController.swift in Sources */,
 				54DFC2996D364B99101BB9CE /* Navigator+Transition.swift in Sources */,

--- a/CustomDynamicFont/Sources/Presentation/CustomFont/UIFont+CustomFont.swift
+++ b/CustomDynamicFont/Sources/Presentation/CustomFont/UIFont+CustomFont.swift
@@ -32,8 +32,11 @@ extension UIFont {
                 )
             )
         } else {
-            // TODO: Implement iOS 10 font scaling logic
-            scaledFont = customFont
+            let sizeCategory = overrideFontSize ?? UIApplication.shared.preferredContentSizeCategory
+            guard let fontIOS10 = font as? DynamicFontIOS10,
+                  let customFontIOS10 = fontIOS10.font(for: style, sizeCategory: sizeCategory)
+            else { return customFont }
+            scaledFont = customFontIOS10
         }
 
         return scaledFont

--- a/CustomDynamicFont/Sources/Presentation/CustomFont/UIFont+DynamicFontIOS10.swift
+++ b/CustomDynamicFont/Sources/Presentation/CustomFont/UIFont+DynamicFontIOS10.swift
@@ -1,0 +1,14 @@
+//  swiftlint:disable:this file_name
+//  UIFont+DynamicFontIOS10.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 18/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+import UIKit
+
+protocol DynamicFontIOS10 {
+
+    func font(for style: UIFont.TextStyle, sizeCategory: UIContentSizeCategory) -> UIFont?
+}

--- a/CustomDynamicFont/Sources/Presentation/CustomFont/ZenOldMincho.swift
+++ b/CustomDynamicFont/Sources/Presentation/CustomFont/ZenOldMincho.swift
@@ -10,10 +10,97 @@ import UIKit
 
 extension UIFont {
 
-    enum ZenOldMincho: DynamicFont {
+    enum ZenOldMincho: DynamicFont, DynamicFontIOS10 {
 
         case regular
         case bold
+
+        static let fontSizeTable: [UIFont.TextStyle: [UIContentSizeCategory: CGFloat]] = [
+            .headline: [
+                .accessibilityExtraExtraExtraLarge: 23,
+                .accessibilityExtraExtraLarge: 23,
+                .accessibilityExtraLarge: 23,
+                .accessibilityLarge: 23,
+                .accessibilityMedium: 23,
+                .extraExtraExtraLarge: 23,
+                .extraExtraLarge: 21,
+                .extraLarge: 19,
+                .large: 17,
+                .medium: 16,
+                .small: 15,
+                .extraSmall: 14
+            ],
+            .subheadline: [
+                .accessibilityExtraExtraExtraLarge: 21,
+                .accessibilityExtraExtraLarge: 21,
+                .accessibilityExtraLarge: 21,
+                .accessibilityLarge: 21,
+                .accessibilityMedium: 21,
+                .extraExtraExtraLarge: 21,
+                .extraExtraLarge: 19,
+                .extraLarge: 17,
+                .large: 15,
+                .medium: 14,
+                .small: 13,
+                .extraSmall: 12
+            ],
+            .body: [
+                .accessibilityExtraExtraExtraLarge: 53,
+                .accessibilityExtraExtraLarge: 47,
+                .accessibilityExtraLarge: 40,
+                .accessibilityLarge: 33,
+                .accessibilityMedium: 28,
+                .extraExtraExtraLarge: 23,
+                .extraExtraLarge: 21,
+                .extraLarge: 19,
+                .large: 17,
+                .medium: 16,
+                .small: 15,
+                .extraSmall: 14
+            ],
+            .caption1: [
+                .accessibilityExtraExtraExtraLarge: 18,
+                .accessibilityExtraExtraLarge: 18,
+                .accessibilityExtraLarge: 18,
+                .accessibilityLarge: 18,
+                .accessibilityMedium: 18,
+                .extraExtraExtraLarge: 18,
+                .extraExtraLarge: 16,
+                .extraLarge: 14,
+                .large: 12,
+                .medium: 11,
+                .small: 11,
+                .extraSmall: 11
+            ],
+            .caption2: [
+                .accessibilityExtraExtraExtraLarge: 17,
+                .accessibilityExtraExtraLarge: 17,
+                .accessibilityExtraLarge: 17,
+                .accessibilityLarge: 17,
+                .accessibilityMedium: 17,
+                .extraExtraExtraLarge: 17,
+                .extraExtraLarge: 15,
+                .extraLarge: 13,
+                .large: 11,
+                .medium: 11,
+                .small: 11,
+                .extraSmall: 11
+            ],
+            .footnote: [
+                .accessibilityExtraExtraExtraLarge: 19,
+                .accessibilityExtraExtraLarge: 19,
+                .accessibilityExtraLarge: 19,
+                .accessibilityLarge: 19,
+                .accessibilityMedium: 19,
+                .extraExtraExtraLarge: 19,
+                .extraExtraLarge: 17,
+                .extraLarge: 15,
+                .large: 13,
+                .medium: 12,
+                .small: 12,
+                .extraSmall: 12
+            ]
+        ]
 
         func fontName() -> String {
             switch self {
@@ -38,6 +125,13 @@ extension UIFont {
             case .caption2: return 11.0
             default: return 17.0
             }
+        }
+
+        func font(for style: UIFont.TextStyle, sizeCategory: UIContentSizeCategory) -> UIFont? {
+            guard let style = ZenOldMincho.fontSizeTable[style],
+                  let size = style[sizeCategory]
+            else { return nil }
+            return UIFont(name: fontName(), size: size)
         }
     }
 }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS10/IOS10ViewController.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS10/IOS10ViewController.swift
@@ -13,6 +13,7 @@ import UIKit
 final class IOS10ViewController: IOS10DynamicFontController {
 
     private var uiKitView: UIKitView?
+    private var fontSize: UIContentSizeCategory?
 
     @Injected private var viewModel: UIKitViewModelProtocol
 
@@ -23,8 +24,7 @@ final class IOS10ViewController: IOS10DynamicFontController {
     }
 
     override func updateFonts(notification _: Notification) {
-        // TODO: Add updating font function in integration
-        print("updating font")
+        uiKitView?.setUpFont(fontSize: fontSize)
     }
 }
 
@@ -43,7 +43,15 @@ extension IOS10ViewController {
     }
 
     private func bindViewModel() {
+        viewModel.input.setOS(version: .ios10)
         viewModel.output.title.drive(rx.title)
+            .disposed(by: disposeBag)
+        viewModel.output.overrideFontSize
+            .asObservable()
+            .withUnretained(self)
+            .subscribe { owner, value in
+                owner.fontSize = value
+            }
             .disposed(by: disposeBag)
     }
 }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS11UIKit/UIKitViewModel.swift
@@ -15,6 +15,7 @@ import RxSwift
 protocol UIKitViewModelInput {
 
     func overrideFontSize(_ index: Int)
+    func setOS(version: OSVersion)
 }
 
 // sourcery: AutoMockable
@@ -60,6 +61,7 @@ final class UIKitViewModel: UIKitViewModelProtocol {
 
     private let overrideFontTrigger = PublishRelay<Bool>()
     private let overrideFontSizeTrigger = PublishRelay<UIContentSizeCategory?>()
+    private let versionTrigger = BehaviorRelay<OSVersion>(value: .iosGreaterOrEqualTo11)
     private let overrideFontSizes: [UIContentSizeCategory] = [.small, .medium, .large, .extraLarge]
 
     private var recentOverrideFontSize: UIContentSizeCategory = .medium
@@ -70,8 +72,12 @@ final class UIKitViewModel: UIKitViewModelProtocol {
     private let disposeBag = DisposeBag()
 
     init() {
-        title = Driver.just(OSVersion.iosGreaterOrEqualTo11.title())
-        osVersion = Driver.just(OSVersion.iosGreaterOrEqualTo11.title())
+        title = versionTrigger
+            .map { $0.title() }
+            .asDriver(onErrorJustReturn: OSVersion.iosGreaterOrEqualTo11.title())
+        osVersion = versionTrigger
+            .map { $0.title() }
+            .asDriver(onErrorJustReturn: OSVersion.iosGreaterOrEqualTo11.title())
         fontName = Driver.just(UIFont.ZenOldMincho.regular.fontName())
         lifecycle = Driver.just(Lifecycle.uiKit.title())
         caption = Driver.just(R.string.localizable.ios11UIKitCommentLabelTitle())
@@ -109,6 +115,10 @@ extension UIKitViewModel: UIKitViewModelInput {
     func overrideFontSize(_ index: Int) {
         recentOverrideFontSize = overrideFontSizes[index]
         overrideFontSizeTrigger.accept(overrideFontSizes[index])
+    }
+
+    func setOS(version: OSVersion) {
+        versionTrigger.accept(version)
     }
 }
 

--- a/CustomDynamicFontTests/Sources/Specs/IOS11UIKit/UIKitViewModelSpec.swift
+++ b/CustomDynamicFontTests/Sources/Specs/IOS11UIKit/UIKitViewModelSpec.swift
@@ -40,13 +40,13 @@ final class UIKitViewModelSpec: QuickSpec {
                 it("returns output with correct title") {
                     expect(viewModel.output.title)
                         .events(scheduler: scheduler, disposeBag: disposeBag)
-                        .to(equal([.next(0, OSVersion.iosGreaterOrEqualTo11.title()), .completed(0)]))
+                        .to(equal([.next(0, OSVersion.iosGreaterOrEqualTo11.title())]))
                 }
 
                 it("returns output with correct osVersion") {
                     expect(viewModel.output.osVersion)
                         .events(scheduler: scheduler, disposeBag: disposeBag)
-                        .to(equal([.next(0, OSVersion.iosGreaterOrEqualTo11.title()), .completed(0)]))
+                        .to(equal([.next(0, OSVersion.iosGreaterOrEqualTo11.title())]))
                 }
 
                 it("returns output with correct fontName") {
@@ -153,6 +153,26 @@ final class UIKitViewModelSpec: QuickSpec {
                     expect(viewModel.output.overrideFontSizeText)
                         .events(scheduler: scheduler, disposeBag: disposeBag)
                         .to(equal([.next(50, UIContentSizeCategory.small.label())]))
+                }
+            }
+
+            context("when input setOS is called") {
+
+                it("returns output correct title and osVersion") {
+                    scheduler.scheduleAt(50) {
+                        viewModel.input.setOS(version: .ios10)
+                    }
+
+                    expect(viewModel.output.title)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([
+                            .next(0, OSVersion.iosGreaterOrEqualTo11.title()),
+                            .next(50, OSVersion.ios10.title())
+                        ]))
+
+                    expect(viewModel.output.osVersion)
+                        .events(scheduler: scheduler, disposeBag: disposeBag)
+                        .to(equal([.next(50, OSVersion.ios10.title())]))
                 }
             }
         }


### PR DESCRIPTION
close #10 
close #12 

## What happened

The following text is custom font and dynamic with device's settings.

Title "iOS 10".
Bold title text "Font Name"
Text "iOS Version"
Text "UIKit"
Caption text "A demo from NimbleHQ"
"Font Name" should be the family name of the custom font.

When the On/Off toggle is tap show when on and hide when off the following:

Label "Override Font Size".
Slider for the font size.
Font size indicator.
Screen's font size changes when the toggle is switched.

When on, override system font size with the slider's setting.
When off, use system font size.
Slider has four values: small, regular, large, x-large.

Slider should change the screen's font size.

Font size indicator updates with value from the slider.
 
## Insight

Add a font size table so that the font change according to style and sizeContent.
 
## Proof Of Work

https://user-images.githubusercontent.com/6356137/142346217-2a810269-0cfe-4e0c-a4a2-f8daab13c078.mp4


