### PR TITLE
[#17] [#18] [UI] [Integrate] As a user, I can see the iOS 12 SwiftUI Screen with Dynamic Custom Font

### DIFF
--- a/CustomDynamicFont.xcodeproj/project.pbxproj
+++ b/CustomDynamicFont.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		096C316527422BBD009497A5 /* Lifecycle+Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096C316427422BBD009497A5 /* Lifecycle+Title.swift */; };
 		097002872754E40B002217F1 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097002862754E40B002217F1 /* MainTabBarController.swift */; };
 		097002892754E9ED002217F1 /* DynamicFontSwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097002882754E9ED002217F1 /* DynamicFontSwiftUIView.swift */; };
+		0970028C2755D14B002217F1 /* ScaledFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0970028B2755D14B002217F1 /* ScaledFont.swift */; };
 		09A81ECF2744B7B3008CBEBD /* UIKitViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */; };
 		09A81EF727456961008CBEBD /* DynamicFontController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81EF627456961008CBEBD /* DynamicFontController.swift */; };
 		09A81EF927456C96008CBEBD /* IOS10DynamicFontController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81EF827456C96008CBEBD /* IOS10DynamicFontController.swift */; };
@@ -137,6 +138,7 @@
 		096C316427422BBD009497A5 /* Lifecycle+Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Lifecycle+Title.swift"; sourceTree = "<group>"; };
 		097002862754E40B002217F1 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		097002882754E9ED002217F1 /* DynamicFontSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFontSwiftUIView.swift; sourceTree = "<group>"; };
+		0970028B2755D14B002217F1 /* ScaledFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaledFont.swift; sourceTree = "<group>"; };
 		09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitViewModelSpec.swift; sourceTree = "<group>"; };
 		09A81EF627456961008CBEBD /* DynamicFontController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFontController.swift; sourceTree = "<group>"; };
 		09A81EF827456C96008CBEBD /* IOS10DynamicFontController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS10DynamicFontController.swift; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 		094CFC9E27352C6300C3A3AD /* CustomFont */ = {
 			isa = PBXGroup;
 			children = (
+				0970028A2755D0FB002217F1 /* SwiftUI */,
 				094CFC9F27352C7F00C3A3AD /* UIFont+CustomFont.swift */,
 				09A81EFC2745E632008CBEBD /* UIFont+DynamicFontIOS10.swift */,
 				094CFCA12738D68400C3A3AD /* ZenOldMincho.swift */,
@@ -342,6 +345,14 @@
 				097002862754E40B002217F1 /* MainTabBarController.swift */,
 			);
 			path = TabBarController;
+			sourceTree = "<group>";
+		};
+		0970028A2755D0FB002217F1 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				0970028B2755D14B002217F1 /* ScaledFont.swift */,
+			);
+			path = SwiftUI;
 			sourceTree = "<group>";
 		};
 		09A81ECC2744B687008CBEBD /* IOS11UIKit */ = {
@@ -1276,6 +1287,7 @@
 				094CFCAC273905FD00C3A3AD /* SelectOSViewModel.swift in Sources */,
 				4D43EAB692C4A66B84807C68 /* AppDelegate.swift in Sources */,
 				094CFCA027352C7F00C3A3AD /* UIFont+CustomFont.swift in Sources */,
+				0970028C2755D14B002217F1 /* ScaledFont.swift in Sources */,
 				D075ABFE0F1A55DA4716271B /* Constants+API.swift in Sources */,
 				1D61304F843D44F002D05AEF /* Constants.swift in Sources */,
 				09B254B2274273B700D3E7F8 /* UIView+AdjustFont.swift in Sources */,

--- a/CustomDynamicFont/Resources/Localizations/en.lproj/Localizable.strings
+++ b/CustomDynamicFont/Resources/Localizations/en.lproj/Localizable.strings
@@ -10,6 +10,7 @@
 "selectOS.navigation.title" = "Dynamic Font";
 "osVersion.ios10.title" = "iOS 10";
 "osVersion.ios11.title" = "iOS >=11";
+"osVersion.ios13.title" = "iOS 13";
 "ios11UIKit.commentLabel.title" = "A demo from NimbleHQ";
 "ios11UIKit.lifecycleLabel.title" = "UIKit";
 "ios12SwiftUI.lifecycleLabel.title" = "SwiftUI";

--- a/CustomDynamicFont/Sources/Presentation/CustomFont/SwiftUI/ScaledFont.swift
+++ b/CustomDynamicFont/Sources/Presentation/CustomFont/SwiftUI/ScaledFont.swift
@@ -1,0 +1,35 @@
+//
+//  ScaledFont.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 30/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+struct ScaledFont: ViewModifier {
+    @Environment(\.sizeCategory) var sizeCategory
+    var name: String
+    var size: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(iOS 14.0, *) {
+            return content.font(.custom(name, size: size))
+        } else {
+            let scaledSize = UIFontMetrics.default.scaledValue(for: size)
+            return content.font(.custom(name, size: scaledSize))
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension View {
+    func scaledFont(
+        font: DynamicFont,
+        forTextStyle style: UIFont.TextStyle
+    ) -> some View {
+        return self.modifier(ScaledFont(name: font.fontName(), size: font.fontSize(style: style)))
+    }
+}

--- a/CustomDynamicFont/Sources/Presentation/CustomFont/SwiftUI/ScaledFont.swift
+++ b/CustomDynamicFont/Sources/Presentation/CustomFont/SwiftUI/ScaledFont.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 @available(iOS 13.0, *)
 struct ScaledFont: ViewModifier {
+
     @Environment(\.sizeCategory) var sizeCategory
     var name: String
     var size: CGFloat
@@ -26,10 +27,11 @@ struct ScaledFont: ViewModifier {
 
 @available(iOS 13.0, *)
 extension View {
+
     func scaledFont(
         font: DynamicFont,
         forTextStyle style: UIFont.TextStyle
     ) -> some View {
-        return self.modifier(ScaledFont(name: font.fontName(), size: font.fontSize(style: style)))
+        return modifier(ScaledFont(name: font.fontName(), size: font.fontSize(style: style)))
     }
 }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/DynamicFontSwiftUIView.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/DynamicFontSwiftUIView.swift
@@ -12,7 +12,23 @@ import SwiftUI
 struct DynamicFontSwiftUIView: View {
     
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ScrollView {
+            VStack(alignment: .center, spacing: 8.0) {
+                Image(uiImage: R.image.color_Rectangle() ?? UIImage())
+                    .resizable()
+                    .frame(width: 260.0, height: 260.0)
+                    .padding(.bottom, 12.0)
+                Text(UIFont.ZenOldMincho.regular.fontName())
+                    .scaledFont(font: UIFont.ZenOldMincho.bold, forTextStyle: .headline)
+                Text(R.string.localizable.osVersionIos13Title())
+                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .body)
+                Text(R.string.localizable.ios12SwiftUILifecycleLabelTitle())
+                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .body)
+                Text(R.string.localizable.ios11UIKitCommentLabelTitle())
+                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .footnote)
+            }
+            .padding([.top, .bottom], 20.0)
+        }
     }
 }
 


### PR DESCRIPTION
close #17 
close #18 

## What happened

Add view to SwiftUI

The following text is custom font and dynamic with device's settings.

Title "SwiftUI".
Bold title text "Font Name"
Text "iOS 12"
Text "SwiftUI"
Caption text "A demo from NimbleHQ"
"Font Name" should be the family name of the custom font.

## Insight

iOS 13 and 14 have different behavior for dynamic font.
 
## Proof Of Work
![Kapture 2021-11-30 at 10 47 09](https://user-images.githubusercontent.com/6356137/143983681-53fc7eaf-6a3d-44fb-8c79-3c82e3ecb070.gif)

