### PR TITLE
[#21] [#22] [UI] [Integration] As a user, I can see the iOS 12 SwiftUI Screen with Dynamic Custom Font

### DIFF
--- a/.github/workflows/automatic_pull_request_review.yml
+++ b/.github/workflows/automatic_pull_request_review.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   review_pull_request:
     name: Pull request review by Danger
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.5.0

--- a/CustomDynamicFont.xcodeproj/project.pbxproj
+++ b/CustomDynamicFont.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		09B254B02742504500D3E7F8 /* UIContentSizeCategory+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */; };
 		09B254B2274273B700D3E7F8 /* UIView+AdjustFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B1274273B600D3E7F8 /* UIView+AdjustFont.swift */; };
 		09B254B6274281E800D3E7F8 /* SelectOSViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */; };
+		09D3BF392759BAEB001545DF /* OverridingFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D3BF382759BAEB001545DF /* OverridingFont.swift */; };
+		09D3BF3B2759BB1F001545DF /* OverridingFont+Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D3BF3A2759BB1F001545DF /* OverridingFont+Title.swift */; };
 		1D61304F843D44F002D05AEF /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176F3A31F864DAC55782333E /* Constants.swift */; };
 		276AF12532733ED2804B89C3 /* Color+Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6044A10B85101A31A3F2C45 /* Color+Application.swift */; };
 		31828B72443073F0960CF05E /* Pods_CustomDynamicFontTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9E2770C1198EAAEF04C4A72 /* Pods_CustomDynamicFontTests.framework */; };
@@ -149,6 +151,8 @@
 		09B254AF2742504500D3E7F8 /* UIContentSizeCategory+Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentSizeCategory+Label.swift"; sourceTree = "<group>"; };
 		09B254B1274273B600D3E7F8 /* UIView+AdjustFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AdjustFont.swift"; sourceTree = "<group>"; };
 		09B254B427427FE000D3E7F8 /* SelectOSViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectOSViewModelSpec.swift; sourceTree = "<group>"; };
+		09D3BF382759BAEB001545DF /* OverridingFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverridingFont.swift; sourceTree = "<group>"; };
+		09D3BF3A2759BB1F001545DF /* OverridingFont+Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OverridingFont+Title.swift"; sourceTree = "<group>"; };
 		176F3A31F864DAC55782333E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		181E6FF11063BAB9ED9D2AFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		21E833D795621A259CC50EC4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -322,6 +326,7 @@
 				094CFCD7273BB2A900C3A3AD /* IOS12SwiftUIViewController.swift */,
 				097002882754E9ED002217F1 /* DynamicFontSwiftUIView.swift */,
 				0970028D2755F1E7002217F1 /* ContentSizeCategory+Label.swift */,
+				09D3BF3A2759BB1F001545DF /* OverridingFont+Title.swift */,
 			);
 			path = iOS12SwiftUI;
 			sourceTree = "<group>";
@@ -780,6 +785,7 @@
 			children = (
 				094CFCAD2739099800C3A3AD /* OSVersion.swift */,
 				096C316227422B88009497A5 /* Lifecycle.swift */,
+				09D3BF382759BAEB001545DF /* OverridingFont.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -1315,6 +1321,7 @@
 				09B254B02742504500D3E7F8 /* UIContentSizeCategory+Label.swift in Sources */,
 				09A81EFD2745E632008CBEBD /* UIFont+DynamicFontIOS10.swift in Sources */,
 				82732721B0C0E075702FAE4B /* Navigator+Scene.swift in Sources */,
+				09D3BF392759BAEB001545DF /* OverridingFont.swift in Sources */,
 				09A81EF927456C96008CBEBD /* IOS10DynamicFontController.swift in Sources */,
 				54DFC2996D364B99101BB9CE /* Navigator+Transition.swift in Sources */,
 				D11A849720B1157FEBECD912 /* Navigator.swift in Sources */,
@@ -1326,6 +1333,7 @@
 				548B5A9B5882008248BD1272 /* UIView+Subviews.swift in Sources */,
 				097002892754E9ED002217F1 /* DynamicFontSwiftUIView.swift in Sources */,
 				09A81EF727456961008CBEBD /* DynamicFontController.swift in Sources */,
+				09D3BF3B2759BB1F001545DF /* OverridingFont+Title.swift in Sources */,
 				726A9ED7039D668C6B1F9AC8 /* Typealiases.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CustomDynamicFont.xcodeproj/project.pbxproj
+++ b/CustomDynamicFont.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		097002872754E40B002217F1 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097002862754E40B002217F1 /* MainTabBarController.swift */; };
 		097002892754E9ED002217F1 /* DynamicFontSwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097002882754E9ED002217F1 /* DynamicFontSwiftUIView.swift */; };
 		0970028C2755D14B002217F1 /* ScaledFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0970028B2755D14B002217F1 /* ScaledFont.swift */; };
+		0970028E2755F1E8002217F1 /* ContentSizeCategory+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0970028D2755F1E7002217F1 /* ContentSizeCategory+Label.swift */; };
 		09A81ECF2744B7B3008CBEBD /* UIKitViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */; };
 		09A81EF727456961008CBEBD /* DynamicFontController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81EF627456961008CBEBD /* DynamicFontController.swift */; };
 		09A81EF927456C96008CBEBD /* IOS10DynamicFontController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A81EF827456C96008CBEBD /* IOS10DynamicFontController.swift */; };
@@ -139,6 +140,7 @@
 		097002862754E40B002217F1 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		097002882754E9ED002217F1 /* DynamicFontSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFontSwiftUIView.swift; sourceTree = "<group>"; };
 		0970028B2755D14B002217F1 /* ScaledFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaledFont.swift; sourceTree = "<group>"; };
+		0970028D2755F1E7002217F1 /* ContentSizeCategory+Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentSizeCategory+Label.swift"; sourceTree = "<group>"; };
 		09A81ECD2744B6C8008CBEBD /* UIKitViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitViewModelSpec.swift; sourceTree = "<group>"; };
 		09A81EF627456961008CBEBD /* DynamicFontController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFontController.swift; sourceTree = "<group>"; };
 		09A81EF827456C96008CBEBD /* IOS10DynamicFontController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS10DynamicFontController.swift; sourceTree = "<group>"; };
@@ -319,6 +321,7 @@
 			children = (
 				094CFCD7273BB2A900C3A3AD /* IOS12SwiftUIViewController.swift */,
 				097002882754E9ED002217F1 /* DynamicFontSwiftUIView.swift */,
+				0970028D2755F1E7002217F1 /* ContentSizeCategory+Label.swift */,
 			);
 			path = iOS12SwiftUI;
 			sourceTree = "<group>";
@@ -1289,6 +1292,7 @@
 				094CFCA027352C7F00C3A3AD /* UIFont+CustomFont.swift in Sources */,
 				0970028C2755D14B002217F1 /* ScaledFont.swift in Sources */,
 				D075ABFE0F1A55DA4716271B /* Constants+API.swift in Sources */,
+				0970028E2755F1E8002217F1 /* ContentSizeCategory+Label.swift in Sources */,
 				1D61304F843D44F002D05AEF /* Constants.swift in Sources */,
 				09B254B2274273B700D3E7F8 /* UIView+AdjustFont.swift in Sources */,
 				7ED2A47D73BC9D924DD97243 /* NetworkAPIError.swift in Sources */,

--- a/CustomDynamicFont/Sources/Domain/Entities/OverridingFont.swift
+++ b/CustomDynamicFont/Sources/Domain/Entities/OverridingFont.swift
@@ -1,0 +1,13 @@
+//
+//  OverridingFont.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 3/12/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+enum OverridingFont: Hashable {
+
+    case isOn
+    case isOff
+}

--- a/CustomDynamicFont/Sources/Presentation/CustomFont/SwiftUI/ScaledFont.swift
+++ b/CustomDynamicFont/Sources/Presentation/CustomFont/SwiftUI/ScaledFont.swift
@@ -14,10 +14,14 @@ struct ScaledFont: ViewModifier {
     @Environment(\.sizeCategory) var sizeCategory
     var name: String
     var size: CGFloat
+    var overrideFontSize: ContentSizeCategory?
 
     func body(content: Content) -> some View {
         if #available(iOS 14.0, *) {
-            return content.font(.custom(name, size: size))
+            let scaledSize = UIFontMetrics.default.scaledValue(for: size, compatibleWith: UITraitCollection(
+                preferredContentSizeCategory: UIContentSizeCategory(overrideFontSize)
+            ))
+            return content.font(.custom(name, size: scaledSize))
         } else {
             let scaledSize = UIFontMetrics.default.scaledValue(for: size)
             return content.font(.custom(name, size: scaledSize))
@@ -30,8 +34,15 @@ extension View {
 
     func scaledFont(
         font: DynamicFont,
-        forTextStyle style: UIFont.TextStyle
+        forTextStyle style: UIFont.TextStyle,
+        overrideFontSize: ContentSizeCategory? = nil
     ) -> some View {
-        return modifier(ScaledFont(name: font.fontName(), size: font.fontSize(style: style)))
+        return modifier(
+            ScaledFont(
+                name: font.fontName(),
+                size: font.fontSize(style: style),
+                overrideFontSize: overrideFontSize
+            )
+        )
     }
 }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/ContentSizeCategory+Label.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/ContentSizeCategory+Label.swift
@@ -1,0 +1,27 @@
+//
+//  ContentSizeCategory+Label.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 30/11/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+extension ContentSizeCategory {
+
+    func label() -> String {
+        switch self {
+        case .small:
+            return R.string.localizable.overrideFontSizeSmallLabel()
+        case .medium:
+            return R.string.localizable.overrideFontSizeNormalLabel()
+        case .large:
+            return R.string.localizable.overrideFontSizeLargeLabel()
+        case .extraLarge:
+            return R.string.localizable.overrideFontSizeExtraLargeLabel()
+        default: return ""
+        }
+    }
+}

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/DynamicFontSwiftUIView.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/DynamicFontSwiftUIView.swift
@@ -5,29 +5,90 @@
 //  Created by Bliss on 29/11/21.
 //  Copyright © 2021 Nimble. All rights reserved.
 //
+// swiftlint:disable closure_body_length
 
+import Combine
 import SwiftUI
 
 @available(iOS 13.0.0, *)
 struct DynamicFontSwiftUIView: View {
     
+    @State private var fontSliderValue: Double = 1.0
+    @State private var selectedOverrideOption = 0
+    @State private var fontSize: ContentSizeCategory?
+    private let overrideFontSizes: [ContentSizeCategory] = [.small, .medium, .large, .extraLarge]
+
     var body: some View {
         ScrollView {
             VStack(alignment: .center, spacing: 8.0) {
                 Image(uiImage: R.image.color_Rectangle() ?? UIImage())
                     .resizable()
                     .frame(width: 260.0, height: 260.0)
-                    .padding(.bottom, 12.0)
+                Spacer(minLength: 4.0)
                 Text(UIFont.ZenOldMincho.regular.fontName())
-                    .scaledFont(font: UIFont.ZenOldMincho.bold, forTextStyle: .headline)
+                    .scaledFont(font: UIFont.ZenOldMincho.bold, forTextStyle: .headline, overrideFontSize: fontSize)
                 Text(R.string.localizable.osVersionIos13Title())
-                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .body)
+                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .body, overrideFontSize: fontSize)
                 Text(R.string.localizable.ios12SwiftUILifecycleLabelTitle())
-                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .body)
+                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .body, overrideFontSize: fontSize)
                 Text(R.string.localizable.ios11UIKitCommentLabelTitle())
-                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .footnote)
+                    .scaledFont(font: UIFont.ZenOldMincho.regular, forTextStyle: .footnote, overrideFontSize: fontSize)
+                Spacer(minLength: 4.0)
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 8.0) {
+                        Text(R.string.localizable.ios11UIKitOverrideFontScaleTitleTitle())
+                            .scaledFont(
+                                font: UIFont.ZenOldMincho.regular,
+                                forTextStyle: .body,
+                                overrideFontSize: fontSize
+                            )
+                        Picker(
+                            selection: $selectedOverrideOption,
+                            content: {
+                                Text(R.string.localizable.ios11UIKitOverrideFontSegmentOptionsOff()).tag(0)
+                                Text(R.string.localizable.ios11UIKitOverrideFontSegmentOptionsOn()).tag(1)
+                            },
+                            label: {}
+                        )
+                        .pickerStyle(.segmented)
+
+                        if selectedOverrideOption == 1 {
+                            Spacer(minLength: 4.0)
+
+                            Text(R.string.localizable.ios11UIKitOverrideFontTitleTitle())
+                                .scaledFont(
+                                    font: UIFont.ZenOldMincho.regular,
+                                    forTextStyle: .body,
+                                    overrideFontSize: fontSize
+                                )
+                            HStack(spacing: 8.0) {
+                                Slider(
+                                    value: $fontSliderValue,
+                                    in: 0 ... Double(overrideFontSizes.count - 1),
+                                    step: 1.0
+                                ) { _ in
+                                    fontSize = overrideFontSizes[Int(fontSliderValue)]
+                                }
+                                if let fontSize = fontSize {
+                                    Text(fontSize.label())
+                                        .scaledFont(
+                                            font: UIFont.ZenOldMincho.regular,
+                                            forTextStyle: .body,
+                                            overrideFontSize: fontSize
+                                        )
+                                }
+                            }
+                        }
+                    }
+                    Spacer()
+                }
             }
+            .padding(.horizontal, 16.0)
             .padding([.top, .bottom], 20.0)
+            .onReceive(Just(selectedOverrideOption), perform: { value in
+                fontSize = value == 1 ? overrideFontSizes[Int(fontSliderValue)] : nil
+            })
         }
     }
 }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/DynamicFontSwiftUIView.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/DynamicFontSwiftUIView.swift
@@ -12,11 +12,12 @@ import SwiftUI
 
 @available(iOS 13.0.0, *)
 struct DynamicFontSwiftUIView: View {
-    
+
     @State private var fontSliderValue: Double = 1.0
-    @State private var selectedOverrideOption = 0
+    @State private var selectedOverrideOption: OverridingFont = .isOff
     @State private var fontSize: ContentSizeCategory?
     private let overrideFontSizes: [ContentSizeCategory] = [.small, .medium, .large, .extraLarge]
+    private let overridingFontOptions: [OverridingFont] = [.isOff, .isOn]
 
     var body: some View {
         ScrollView {
@@ -46,14 +47,15 @@ struct DynamicFontSwiftUIView: View {
                         Picker(
                             selection: $selectedOverrideOption,
                             content: {
-                                Text(R.string.localizable.ios11UIKitOverrideFontSegmentOptionsOff()).tag(0)
-                                Text(R.string.localizable.ios11UIKitOverrideFontSegmentOptionsOn()).tag(1)
+                                ForEach(overridingFontOptions, id: \.self) {
+                                    Text($0.title()).tag($0)
+                                }
                             },
                             label: {}
                         )
                         .pickerStyle(.segmented)
 
-                        if selectedOverrideOption == 1 {
+                        if selectedOverrideOption == .isOn {
                             Spacer(minLength: 4.0)
 
                             Text(R.string.localizable.ios11UIKitOverrideFontTitleTitle())
@@ -87,7 +89,7 @@ struct DynamicFontSwiftUIView: View {
             .padding(.horizontal, 16.0)
             .padding([.top, .bottom], 20.0)
             .onReceive(Just(selectedOverrideOption), perform: { value in
-                fontSize = value == 1 ? overrideFontSizes[Int(fontSliderValue)] : nil
+                fontSize = value == .isOn ? overrideFontSizes[Int(fontSliderValue)] : nil
             })
         }
     }

--- a/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/OverridingFont+Title.swift
+++ b/CustomDynamicFont/Sources/Presentation/Modules/iOS12SwiftUI/OverridingFont+Title.swift
@@ -1,0 +1,19 @@
+//
+//  OverridingFont+Title.swift
+//  CustomDynamicFont
+//
+//  Created by Bliss on 3/12/21.
+//  Copyright © 2021 Nimble. All rights reserved.
+//
+
+extension OverridingFont {
+
+    func title() -> String {
+        switch self {
+        case .isOn:
+            return R.string.localizable.ios11UIKitOverrideFontSegmentOptionsOn()
+        case .isOff:
+            return R.string.localizable.ios11UIKitOverrideFontSegmentOptionsOff()
+        }
+    }
+}


### PR DESCRIPTION
close #21
close #22  

## What happened

When the On/Off toggle is tap show when on and hide when off the following:

Label "Override Font Size".
Slider for the font size.
Font size indicator.
Screen's font size changes when the toggle is switched.

When on, override system font size with the slider's setting.
When off, use system font size.
Slider has four values: small, regular, large, x-large.

Slider should change the screen's font size.

Font size indicator updates with value from the slider.

## Insight

Add `overrideContentSize` to SwiftUI font.
  
## Proof Of Work
![Kapture 2021-11-30 at 12 53 35](https://user-images.githubusercontent.com/6356137/144002049-d066eb83-3581-44f0-8895-7788e3edc08e.gif)


